### PR TITLE
Add split option to split large input into smaller parts instead of truncating

### DIFF
--- a/ttok/cli.py
+++ b/ttok/cli.py
@@ -1,6 +1,7 @@
 import click
 import sys
 import tiktoken
+from itertools import zip_longest
 
 
 @click.command()
@@ -10,9 +11,10 @@ import tiktoken
 @click.option(
     "-t", "--truncate", "truncate", type=int, help="Truncate to this many tokens"
 )
+@click.option("-s", "--split", "split_file", type=click.Path(), help="Split input into multiple files")
 @click.option("-m", "--model", default="gpt-3.5-turbo", help="Which model to use")
 @click.option("output_tokens", "--tokens", is_flag=True, help="Output token integers")
-def cli(prompt, input, truncate, model, output_tokens):
+def cli(prompt, input, truncate, split_file, model, output_tokens):
     """
     Count and truncate text based on tokens
 
@@ -51,6 +53,21 @@ def cli(prompt, input, truncate, model, output_tokens):
             text = input_text
     # Tokenize it
     tokens = encoding.encode(text)
+
+    if split_file and truncate:
+        # Ensure the truncate value is valid
+        if truncate <= 0:
+            raise click.ClickException(f"Invalid truncate value: {truncate}")
+        # Split the tokens into groups of the specified size
+        chunks = grouper(tokens, truncate)
+        # Write each chunk to a separate file
+        for i, chunk in enumerate(chunks):
+            with open(f"{split_file}.part{i}", "w") as f:
+                chunk = [token for token in chunk if token is not None]
+                decoded_chunk = encoding.decode(chunk)
+                f.write(decoded_chunk)
+        return  # Exit the function early, we don't need to do anything else in this case
+
     if truncate:
         tokens = tokens[:truncate]
 
@@ -60,3 +77,9 @@ def cli(prompt, input, truncate, model, output_tokens):
         click.echo(encoding.decode(tokens), nl=False)
     else:
         click.echo(len(tokens))
+
+def grouper(iterable, n, fillvalue=None):
+    "Collect data into fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    args = [iter(iterable)] * n
+    return zip_longest(fillvalue=fillvalue, *args)


### PR DESCRIPTION
Sometimes, I don't want to discard the remaining output, might be useful :)
So, this pull request adds a new feature to the token counting command-line interface. The new -s or --split option allows users to split their input text into multiple files, each containing a specific number of tokens. 

### Changes
1. A new option (-s, --split) has been added to the `click.command()` decorator in the `cli` function.
2. The `cli` function has been updated to handle this new option. When the `split` and `truncate` options are used together, the script splits the input tokens into groups of the specified size and writes each group to a separate file. 
3. A new helper function `grouper` has been added to split an iterable into fixed-length chunks.
4. The split function now decodes each chunk before writing to the respective output file.


