### PR TITLE
Add new OpenAI models to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,11 @@ import tiktoken
 output = []
 for key, value in tiktoken.model.MODEL_TO_ENCODING.items():
     output.append("- `{}` (`{}`)".format(key, value))
+for key, value in tiktoken.model.MODEL_PREFIX_TO_ENCODING.items():
+    output.append("- `{}` (`{}`)".format(key, value))
 cog.out("\n".join(output))
 ]]] -->
+- `gpt-4o` (`o200k_base`)
 - `gpt-4` (`cl100k_base`)
 - `gpt-3.5-turbo` (`cl100k_base`)
 - `gpt-3.5` (`cl100k_base`)
@@ -165,6 +168,16 @@ cog.out("\n".join(output))
 - `code-search-ada-code-001` (`r50k_base`)
 - `gpt2` (`gpt2`)
 - `gpt-2` (`gpt2`)
+- `o1-` (`o200k_base`)
+- `chatgpt-4o-` (`o200k_base`)
+- `gpt-4o-` (`o200k_base`)
+- `gpt-4-` (`cl100k_base`)
+- `gpt-3.5-turbo-` (`cl100k_base`)
+- `gpt-35-turbo-` (`cl100k_base`)
+- `ft:gpt-4` (`cl100k_base`)
+- `ft:gpt-3.5-turbo` (`cl100k_base`)
+- `ft:davinci-002` (`cl100k_base`)
+- `ft:babbage-002` (`cl100k_base`)
 <!-- [[[end]]] -->
 
 ## ttok --help


### PR DESCRIPTION
As `ttok` relies on `tiktoken`, new models are supported out of the box. This PR also extends the list of supported models to `MODEL_PREFIX_TO_ENCODING` to include o1. However, it might become deprecated in the future, see [this line](https://github.com/openai/tiktoken/blob/63527649963def8c759b0f91f2eb69a40934e468/tiktoken/model.py#L6). Alternatively, the README could be simplified by saying that all `tiktoken` models are supported.