### PR TITLE
Chunksize - a simple approach to splitting

### DIFF
--- a/tests/test_ttok.py
+++ b/tests/test_ttok.py
@@ -61,6 +61,9 @@ def test_ttok_count_and_tokens(args, expected_length, expected_tokens):
             [b"86127", b"15682", b"48864", b"21990", b"38641", "--decode", "--tokens"],
             "[b'\\xe7\\xa7\\x81', b'\\xe3\\x81\\xaf', b'\\xe5\\xad\\xa6', b'\\xe7\\x94\\x9f', b'\\xe3\\x81\\xa7\\xe3\\x81\\x99']",
         ),
+        (["hello", "big", "world", "out", "there", "--tokens", "--chunksize", "2"], "[b'hello', b' big']\n[b' world', b' out']\n[b' there']"),
+        (["hello", "big", "world", "out", "there", "--chunksize", "2"], "hello big\n world out\n there"),
+        (["hello", "big", "world", "out", "there", "--encode", "--chunksize", "2"], "15339 2466\n1917 704\n1070"),
     ),
 )
 def test_ttok_decode_encode_tokens(args, expected):

--- a/ttok/cli.py
+++ b/ttok/cli.py
@@ -20,6 +20,7 @@ import tiktoken
 )
 @click.option("as_tokens", "--tokens", is_flag=True, help="Output full tokens")
 @click.option("--allow-special", is_flag=True, help="Do not error on special tokens")
+@click.option("--chunksize", type=int, help="Output chunks of this size")
 def cli(
     prompt,
     input,
@@ -29,6 +30,7 @@ def cli(
     decode_tokens,
     as_tokens,
     allow_special,
+    chunksize,
 ):
     """
     Count and truncate text based on tokens
@@ -113,12 +115,24 @@ def cli(
     if truncate:
         tokens = tokens[:truncate]
 
+    if chunksize:
+        chunks = [tokens[i:i + chunksize] for i in range(0, len(tokens), chunksize)]
+    else:
+        chunks = [tokens]
+
     if encode_tokens:
         if as_tokens:
-            click.echo(encoding.decode_tokens_bytes(tokens))
+            for chunk in chunks:
+                click.echo(encoding.decode_tokens_bytes(chunk))
         else:
-            click.echo(" ".join(str(t) for t in tokens))
+            for chunk in chunks:
+                click.echo(" ".join(str(t) for t in chunk))
+    elif chunksize:
+        for chunk in chunks:
+            click.echo(encoding.decode(chunk))
+            click.echo("HEREUR")
     elif truncate:
         click.echo(encoding.decode(tokens), nl=False)
     else:
         click.echo(len(tokens))
+

--- a/ttok/cli.py
+++ b/ttok/cli.py
@@ -130,7 +130,6 @@ def cli(
     elif chunksize:
         for chunk in chunks:
             click.echo(encoding.decode(chunk))
-            click.echo("HEREUR")
     elif truncate:
         click.echo(encoding.decode(tokens), nl=False)
     else:


### PR DESCRIPTION
This change implements a simple alternative to https://github.com/simonw/ttok/pull/2/files. It does not deal with output files, and instead simply prints each chunk sequentially by the existing output mechanism.

When producing text output this is uninteresting. With `--tokens` it gives readable split output. Combined with `--encode` it produces one encoded chunk per line, output that can be piped to `split -l 1 prefix`, which can be decoded later. This makes it straightforward to split long text into chunks for embedding or other purposes.